### PR TITLE
Add `render.yaml` to configure the project for deployment on Render a…

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,6 @@
+services:
+  - type: static
+    name: ai-marketing-news-media
+    env: static
+    buildCommand: npm install && npm run build
+    staticPublishPath: build


### PR DESCRIPTION
…s a Static Site.

The configuration sets the build command to `npm install && npm run build` and the publish directory to `build`.

This allows for automated "Infrastructure as Code" deployments from the Render dashboard.