### PR TITLE
Correct the service definition in `render.yaml` for a static site.

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,6 +1,6 @@
 services:
-  - type: static
+  - type: web
     name: ai-marketing-news-media
-    env: static
+    runtime: static
     buildCommand: npm install && npm run build
     staticPublishPath: build


### PR DESCRIPTION
The previous configuration used `type: static`, which is not a valid service type according to Render's blueprint specification. The correct configuration for a static site is `type: web` combined with `runtime: static`.

This change updates the `render.yaml` file to use the correct syntax, resolving the 'unknown type' error during deployment.