### PR TITLE
feat: フルワイドレイアウトを実装

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -442,21 +442,8 @@
   }
 
   .container {
-    max-width: var(--container-7xl);
-    padding-inline: calc(var(--spacing) * 4);
+    width: 100%;
     margin-inline: auto;
-  }
-
-  @media (width >= 40rem) {
-    .container {
-      padding-inline: calc(var(--spacing) * 6);
-    }
-  }
-
-  @media (width >= 64rem) {
-    .container {
-      padding-inline: calc(var(--spacing) * 8);
-    }
   }
 
   :where(:not(:has([class*=" text-"]), :not(:has([class^="text-"])))) h1 {
@@ -701,40 +688,6 @@
 
   .row-start-1 {
     grid-row-start: 1;
-  }
-
-  .container {
-    width: 100%;
-  }
-
-  @media (width >= 40rem) {
-    .container {
-      max-width: 40rem;
-    }
-  }
-
-  @media (width >= 48rem) {
-    .container {
-      max-width: 48rem;
-    }
-  }
-
-  @media (width >= 64rem) {
-    .container {
-      max-width: 64rem;
-    }
-  }
-
-  @media (width >= 80rem) {
-    .container {
-      max-width: 80rem;
-    }
-  }
-
-  @media (width >= 96rem) {
-    .container {
-      max-width: 96rem;
-    }
   }
 
   .-mx-1 {


### PR DESCRIPTION
ユーザーの要望に基づき、サイトのレイアウトをフルワイドに変更しました。以前のバージョンでは、左右に広い余白がありました。

この変更では、グローバルスタイルシート（`src/index.css`）の`.container`クラスを修正しました。レイアウトの幅を制限していた`max-width`と`padding-inline`プロパティを削除することで、`.container`クラスを使用するすべてのセクションがビューポートの全幅に広がるようになります。