### PR TITLE
feat: サイトの左右の余白を狭く調整

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -442,8 +442,21 @@
   }
 
   .container {
-    width: 100%;
+    max-width: var(--container-7xl);
+    padding-inline: calc(var(--spacing) * 2);
     margin-inline: auto;
+  }
+
+  @media (width >= 40rem) {
+    .container {
+      padding-inline: calc(var(--spacing) * 3);
+    }
+  }
+
+  @media (width >= 64rem) {
+    .container {
+      padding-inline: calc(var(--spacing) * 4);
+    }
   }
 
   :where(:not(:has([class*=" text-"]), :not(:has([class^="text-"])))) h1 {
@@ -688,6 +701,40 @@
 
   .row-start-1 {
     grid-row-start: 1;
+  }
+
+  .container {
+    width: 100%;
+  }
+
+  @media (width >= 40rem) {
+    .container {
+      max-width: 40rem;
+    }
+  }
+
+  @media (width >= 48rem) {
+    .container {
+      max-width: 48rem;
+    }
+  }
+
+  @media (width >= 64rem) {
+    .container {
+      max-width: 64rem;
+    }
+  }
+
+  @media (width >= 80rem) {
+    .container {
+      max-width: 80rem;
+    }
+  }
+
+  @media (width >= 96rem) {
+    .container {
+      max-width: 96rem;
+    }
   }
 
   .-mx-1 {


### PR DESCRIPTION
ユーザーからのフィードバックに基づき、レイアウトの左右の余白を調整しました。

前回のフルワイドレイアウトへの変更は意図したデザインと異なったため、元に戻しました。代わりに、`.container`クラスの`padding-inline`の値を約半分に減らすことで、余白がより狭くなるように修正しました。

これにより、コンテンツの表示領域が広がりつつも、極端なフルワイドレイアウトは回避されます。