### PR TITLE
feat: サイト全体のフォントをNoto Sans JPに変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,12 @@
       <meta charset="UTF-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       <title>AI Marketing Newsオウンドメディア</title>
+      <link rel="preconnect" href="https://fonts.googleapis.com" />
+      <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+      <link
+        href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600;700&display=swap"
+        rel="stylesheet"
+      />
     </head>
 
     <body>

--- a/src/index.css
+++ b/src/index.css
@@ -79,7 +79,7 @@
 
 @layer theme {
   :root, :host {
-    --font-sans: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    --font-sans: "Noto Sans JP", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
     --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     --color-red-50: oklch(.971 .013 17.38);
     --color-red-200: oklch(.885 .062 18.334);


### PR DESCRIPTION
ユーザーの要望に基づき、サイト全体の基本フォントを「Noto Sans JP」に変更しました。

- `index.html`にGoogle Fontsから「Noto Sans JP」を読み込むための`<link>`タグを追加しました。フォントウェイトは400, 500, 600, 700をインポートしています。
- `src/index.css`の`--font-sans` CSS変数を更新し、フォントスタックの先頭に「Noto Sans JP」を追加しました。